### PR TITLE
feat: 自动提取文章第一张图片作为社交媒体预览图

### DIFF
--- a/layouts/partials/templates/opengraph.html
+++ b/layouts/partials/templates/opengraph.html
@@ -1,9 +1,20 @@
+{{- /* 提取图片：优先使用 cover.image，否则自动提取文章中第一张图片 */ -}}
+{{- $image := "" -}}
+{{- with .Params.cover.image -}}
+  {{- $image = . -}}
+{{- else -}}
+  {{- $matches := findRE `!\[.*?\]\((/[^)]+)\)` .RawContent 1 -}}
+  {{- with $matches -}}
+    {{- $image = replaceRE `!\[.*?\]\((/[^)]+)\)` "$1" (index . 0) -}}
+  {{- end -}}
+{{- end -}}
+
 <meta property="og:title" content="{{ .Title | default site.Title }}" />
 <meta property="og:description" content="{{ with .Description | default .Summary | default site.Params.description }}{{ . }}{{ end }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 
-{{- with .Params.cover.image -}}
+{{- with $image -}}
 <meta property="og:image" content="{{ (. | absURL) | default " " }}" />
 {{- end -}}
 

--- a/layouts/partials/templates/opengraph.html
+++ b/layouts/partials/templates/opengraph.html
@@ -1,6 +1,8 @@
-{{- /* 提取图片：优先使用 cover.image，否则自动提取文章中第一张图片 */ -}}
+{{- /* 提取图片优先级：cover.image > thumbnail > 文章中第一张图片 */ -}}
 {{- $image := "" -}}
 {{- with .Params.cover.image -}}
+  {{- $image = . -}}
+{{- else with .Params.thumbnail -}}
   {{- $image = . -}}
 {{- else -}}
   {{- $matches := findRE `!\[.*?\]\((/[^)]+)\)` .RawContent 1 -}}

--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -1,6 +1,8 @@
-{{- /* 提取图片：优先使用 cover.image，否则自动提取文章中第一张图片 */ -}}
+{{- /* 提取图片优先级：cover.image > thumbnail > 文章中第一张图片 */ -}}
 {{- $image := "" -}}
 {{- with .Params.cover.image -}}
+  {{- $image = . -}}
+{{- else with .Params.thumbnail -}}
   {{- $image = . -}}
 {{- else -}}
   {{- $matches := findRE `!\[.*?\]\((/[^)]+)\)` .RawContent 1 -}}

--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -1,4 +1,15 @@
+{{- /* 提取图片：优先使用 cover.image，否则自动提取文章中第一张图片 */ -}}
+{{- $image := "" -}}
 {{- with .Params.cover.image -}}
+  {{- $image = . -}}
+{{- else -}}
+  {{- $matches := findRE `!\[.*?\]\((/[^)]+)\)` .RawContent 1 -}}
+  {{- with $matches -}}
+    {{- $image = replaceRE `!\[.*?\]\((/[^)]+)\)` "$1" (index . 0) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $image -}}
 <meta name="twitter:card" content="summary_large_image" />
 {{- else -}}
 <meta name="twitter:card" content="summary"/>
@@ -12,6 +23,6 @@
 {{- with .Description | default .Summary | default site.Params.description }}
 <meta name="twitter:description" content="{{ . }}" />
 {{- end -}}
-{{- with .Params.cover.image -}}
+{{- with $image -}}
 <meta name="twitter:image" content="{{ (. | absURL) | default " " }}"/>
 {{ end -}} 


### PR DESCRIPTION
修改 Twitter Card 和 Open Graph 模板，当文章没有设置 cover.image 时，
自动从文章内容中提取第一张 Markdown 图片作为预览图，这样分享到 X 等
社交媒体时可以显示文章的头图。