### PR TITLE
fix: 修复移动端搜索入口消失的问题

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -108,11 +108,11 @@
         </div>
         {{- $currentPage := . }}
         <ul id="menu">
-            <!-- Search Icon (always visible) -->
+            <!-- Search Icon (always visible, including mobile) -->
             {{- range site.Menus.main }}
             {{- if eq .Identifier "search" }}
             {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
-            <li>
+            <li class="show-more-on-mobile">
                 <a href="{{ .URL | absLangURL }}" title="{{ .Title | default .Name }} (Alt + /)" accesskey="/">
                     <span>
                         {{- .Pre }}


### PR DESCRIPTION
搜索图标的 <li> 没有 show-more-on-mobile 类，被移动端 CSS 规则
li:not(.show-more-on-mobile) { display: none } 隐藏了。
添加 show-more-on-mobile 类后，搜索图标在移动端始终可见。

https://claude.ai/code/session_01Q8R9wc87f2bZyvpwfEiXkb