### PR TITLE
Replace medium-zoom with PhotoSwipe for image viewing

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -1050,6 +1050,12 @@ pre code {
     }
 }
 
+/* PhotoSwipe 图片放大链接：去掉文字链接的下划线样式 */
+.post-content a.post-image-zoom {
+    box-shadow: none;
+    cursor: zoom-in;
+}
+
 /* 打印样式 */
 @media print {
     .toc-sidebar {

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,29 @@
+{{- /* 覆盖 PaperMod 默认的图片渲染，为正文图片包裹 PhotoSwipe 所需的 <a> 容器 */ -}}
+{{- $u := urls.Parse .Destination -}}
+{{- $src := $u.String -}}
+{{- $width := "" -}}
+{{- $height := "" -}}
+{{- if not $u.IsAbs -}}
+  {{- $path := strings.TrimPrefix "./" $u.Path }}
+  {{- with or (.PageInner.Resources.Get $path) (resources.Get $path) -}}
+    {{- $src = .RelPermalink -}}
+    {{- $width = .Width -}}
+    {{- $height = .Height -}}
+    {{- with $u.RawQuery -}}
+      {{- $src = printf "%s?%s" $src . -}}
+    {{- end -}}
+    {{- with $u.Fragment -}}
+      {{- $src = printf "%s#%s" $src . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $attributes := merge .Attributes (dict "alt" .Text "src" $src "title" (.Title | transform.HTMLEscape) "loading" "lazy") -}}
+<a href="{{ $src }}" class="post-image-zoom" target="_blank" rel="noopener"{{ if $width }} data-pswp-width="{{ $width }}"{{ end }}{{ if $height }} data-pswp-height="{{ $height }}"{{ end }}>
+<img
+  {{- range $k, $v := $attributes -}}
+    {{- if $v -}}
+      {{- printf " %s=%q" $k $v | safeHTMLAttr -}}
+    {{- end -}}
+  {{- end -}}>
+</a>
+{{- /**/ -}}

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -48,15 +48,18 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
-{{- /* medium-zoom 初始化：正文图片点击放大 */ -}}
+{{- /* PhotoSwipe 初始化：正文图片点击放大，原生支持移动端双指捏合缩放、双击缩放、拖动平移 */ -}}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    if (typeof mediumZoom === 'undefined') return;
-    mediumZoom('.post-content img:not(.no-zoom)', {
-        margin: 24,
-        background: 'rgba(0, 0, 0, 0.85)',
-        scrollOffset: 0,
+    if (typeof PhotoSwipeLightbox === 'undefined' || typeof PhotoSwipe === 'undefined') return;
+    var lightbox = new PhotoSwipeLightbox({
+        gallery: '.post-content',
+        children: 'a.post-image-zoom',
+        pswpModule: PhotoSwipe,
+        bgOpacity: 0.85,
+        showHideAnimationType: 'zoom',
     });
+    lightbox.init();
 });
 </script>
 

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -3,8 +3,10 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;500;600;700;900&display=swap" rel="stylesheet">
 
-<!-- medium-zoom：正文图片点击放大 -->
-<script defer src="https://cdn.jsdelivr.net/npm/medium-zoom@1.1.0/dist/medium-zoom.min.js"></script>
+<!-- PhotoSwipe：正文图片点击放大，支持移动端双指捏合缩放 -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/photoswipe@5.4.4/dist/photoswipe.css">
+<script defer src="https://cdn.jsdelivr.net/npm/photoswipe@5.4.4/dist/umd/photoswipe.umd.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/photoswipe@5.4.4/dist/umd/photoswipe-lightbox.umd.min.js"></script>
 
 <!-- 自定义 JavaScript 文件 -->
 {{- $relativeDate := resources.Get "js/relative-date.js" | resources.Minify | resources.Fingerprint "sha512" }}


### PR DESCRIPTION
## Summary
This PR replaces the medium-zoom library with PhotoSwipe for image viewing functionality, providing enhanced mobile support with native pinch-to-zoom, double-tap zoom, and drag-to-pan gestures.

## Key Changes
- **New image render template** (`layouts/_default/_markup/render-image.html`): Created a custom Hugo markdown image renderer that wraps images in PhotoSwipe-compatible anchor tags with dimension metadata
- **Updated dependencies**: Replaced medium-zoom CDN links with PhotoSwipe v5.4.4 (CSS + two JS modules)
- **Image initialization script**: Refactored the image zoom initialization from medium-zoom to PhotoSwipe's lightbox API with proper module detection
- **Styling updates**: Added CSS rules for `.post-image-zoom` links to remove underlines and set appropriate cursor styling

## Implementation Details
- The new render template handles both absolute and relative image paths, resolving relative paths through Hugo's resource system
- PhotoSwipe dimensions are passed via `data-pswp-width` and `data-pswp-height` attributes for optimal rendering
- The lightbox is initialized with 0.85 background opacity and zoom animation type to match previous behavior
- Images are selected via the `.post-image-zoom` class within `.post-content` for gallery functionality

https://claude.ai/code/session_01T38b5SDScqgA8ac3PYGgA4