### PR TITLE
fix(rss): 添加 channel image 元素，修复订阅源头像缺失

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -87,6 +87,9 @@ params:
     minMatchCharLength: 0
     keys: ["title", "permalink", "summary", "content"]
   
+  # RSS 订阅头像/Logo
+  images: ["/android-chrome-512x512.png"]
+
   # Favicon 配置
   favicon: "/favicon.ico"
   favicon16x16: "/favicon-16x16.png"

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -21,6 +21,13 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    {{- with .Site.Params.images }}
+    <image>
+      <title>{{ $.Site.Title }}</title>
+      <url>{{ index . 0 | absURL }}</url>
+      <link>{{ $.Permalink }}</link>
+    </image>
+    {{- end }}
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}


### PR DESCRIPTION
自定义的 rss.xml 模板一直没有输出 <image> 标签，导致 RSS 阅读器
（Feedly、Inoreader 等）无法获取站点头像。补上该标签并配置
params.images 指向站点 logo。